### PR TITLE
Update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-            node-version: 12
+            node-version: 16
       - name: Install Dependencies
         run: | # We install documentation.js globally so that we can use `documentation` instead of `node_modules/.../documentation`. We also then install it to save as a dependency.
           npm install
@@ -39,9 +39,12 @@ jobs:
           git fetch
           git checkout gh-pages
           git pull origin gh-pages
-          rm -rf ./*
+          rm -rf ./*.*
           git checkout main -- docs/.vuepress/dist/
           rm -rf assets/
+          mkdir ${{ github.event.release.tag_name }}
+          mv docs/.vuepress/dist/* ${{ github.event.release.tag_name }}
+          git checkout main -- docs/.vuepress/dist/
           mv docs/.vuepress/dist/* ./
           rm -rf docs/
           git checkout main -- demo/


### PR DESCRIPTION
Updates the docs workflow to allow for documentation to be stashed for people using previous versions. Version 1 will go in the root directory and the `v1` directory, while Version 2 will go in the root directory, replacing the previous versions documentation, _but only in the root directory_, and then in the `v2`, so that people using `v1` can still access their documentation.