### PR TITLE
Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,17 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12
-            - run: echo "Working"
-
     publish-npm:
-        needs: build
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -24,13 +14,11 @@ jobs:
               with:
                   node-version: 12
                   registry-url: "https://registry.npmjs.org"
-            - run: npm install
             - run: npm publish --access=public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     publish-gpr:
-        needs: build
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -39,7 +27,6 @@ jobs:
                   node-version: 12
                   registry-url: "https://npm.pkg.github.com"
                   scope: "@quantalabs"
-            - run: npm install
             - run: echo "registry=https://npm.pkg.github.com/@quantalabs" >> .npmrc
             - run: npm publish --access=public
               env:


### PR DESCRIPTION
Updates the publish workflow to stop running `npm ci` and `npm install` as those are not needed on installation.